### PR TITLE
[codex] validate OpenMHz adapter from deployed host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 coverage
 *.tsbuildinfo
 data/openmhz/**/*.json
+.vercel

--- a/app/api/ingest/openmhz/diagnose/route.ts
+++ b/app/api/ingest/openmhz/diagnose/route.ts
@@ -1,0 +1,122 @@
+import { NextResponse } from "next/server";
+
+import { getEnv } from "@/lib/config/env";
+
+export const dynamic = "force-dynamic";
+
+type EndpointCheck = {
+  name: string;
+  path: string;
+};
+
+type EndpointResult = {
+  name: string;
+  url: string;
+  ok: boolean;
+  status: number | null;
+  contentType: string | null;
+  bodyPreview: string;
+  jsonKeys: string[] | null;
+  error?: string;
+};
+
+const ENDPOINTS: EndpointCheck[] = [
+  { name: "talkgroups", path: "/talkgroups" },
+  { name: "calls/latest", path: "/calls/latest" },
+  { name: "calls/newer", path: "/calls/newer?time=0" },
+];
+
+function formatPreview(body: string): string {
+  return body.replace(/\s+/g, " ").trim().slice(0, 240);
+}
+
+function resolveBaseUrl(request: Request): string {
+  const env = getEnv();
+  const { searchParams } = new URL(request.url);
+  return (
+    searchParams.get("baseUrl") ??
+    env.OPENMHZ_API_BASE_URL ??
+    "https://api.openmhz.com"
+  );
+}
+
+function resolveSystem(request: Request): string {
+  const env = getEnv();
+  const { searchParams } = new URL(request.url);
+  return searchParams.get("system") ?? env.OPENMHZ_SYSTEM;
+}
+
+async function fetchEndpoint(
+  baseUrl: string,
+  system: string,
+  endpoint: EndpointCheck,
+): Promise<EndpointResult> {
+  const url = new URL(`/${system}${endpoint.path}`, baseUrl).toString();
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json, text/plain;q=0.9, */*;q=0.8",
+        "User-Agent":
+          "Mozilla/5.0 (compatible; franklin-safety-map-adapter-check/1.0)",
+      },
+      cache: "no-store",
+    });
+
+    const contentType = response.headers.get("content-type");
+    const body = await response.text();
+    let jsonKeys: string[] | null = null;
+
+    if (contentType?.includes("application/json")) {
+      try {
+        const parsed = JSON.parse(body) as unknown;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          jsonKeys = Object.keys(parsed as Record<string, unknown>).slice(0, 12);
+        }
+      } catch {
+        jsonKeys = null;
+      }
+    }
+
+    return {
+      name: endpoint.name,
+      url,
+      ok: response.ok,
+      status: response.status,
+      contentType,
+      bodyPreview: formatPreview(body),
+      jsonKeys,
+    };
+  } catch (error) {
+    return {
+      name: endpoint.name,
+      url,
+      ok: false,
+      status: null,
+      contentType: null,
+      bodyPreview: "",
+      jsonKeys: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function GET(request: Request) {
+  const baseUrl = resolveBaseUrl(request);
+  const system = resolveSystem(request);
+  const results = await Promise.all(
+    ENDPOINTS.map((endpoint) => fetchEndpoint(baseUrl, system, endpoint)),
+  );
+
+  const okCount = results.filter((result) => result.ok).length;
+
+  return NextResponse.json(
+    {
+      baseUrl,
+      system,
+      okCount,
+      results,
+    },
+    { status: okCount === results.length ? 200 : 207 },
+  );
+}

--- a/lib/config/env.ts
+++ b/lib/config/env.ts
@@ -7,8 +7,8 @@ dotenv.config();
 const envSchema = z.object({
   INGEST_SOURCE: z.enum(["openmhz"]).default("openmhz"),
   OPENMHZ_SYSTEM: z.string().default("frkoh"),
-  OPENMHZ_API_BASE_URL: z.string().optional(),
-  OPENMHZ_ADAPTER_BASE_URL: z.string().optional(),
+  OPENMHZ_API_BASE_URL: z.string().trim().optional(),
+  OPENMHZ_ADAPTER_BASE_URL: z.string().trim().optional(),
   OPENMHZ_ADAPTER_CALLS_PATH: z.string().default("/api/ingest/openmhz/calls"),
   OPENMHZ_ADAPTER_MODE: z.enum(["direct", "fixture"]).default("direct"),
   OPENMHZ_ADAPTER_TOKEN: z.string().optional(),

--- a/lib/openmhz/client.ts
+++ b/lib/openmhz/client.ts
@@ -144,6 +144,11 @@ function buildAllowedTalkgroups(envValue?: string): Set<number> | null {
 
 export class OpenMhzHttpClient implements OpenMhzClient {
   private talkgroupsCache?: OpenMhzTalkgroupMap;
+  private readonly requestHeaders: HeadersInit = {
+    Accept: "application/json, text/plain;q=0.9, */*;q=0.8",
+    "User-Agent":
+      "Mozilla/5.0 (compatible; franklin-safety-map-ingest/1.0)",
+  };
 
   constructor(
     private readonly system = getEnv().OPENMHZ_SYSTEM,
@@ -198,7 +203,7 @@ export class OpenMhzHttpClient implements OpenMhzClient {
     }
 
     const response = await fetch(url, {
-      headers: { Accept: "application/json" },
+      headers: this.requestHeaders,
       cache: "no-store",
     });
 


### PR DESCRIPTION
## Summary
- add a deployed-runtime diagnostic endpoint for OpenMHz metadata reachability checks (`/api/ingest/openmhz/diagnose`)
- harden the OpenMHz fetch client used by the adapter path (trimmed base URLs + browser-compatible request headers)
- validate that the deployed adapter can return normalized live `frkoh` calls from OpenMHz

## Runtime Validation Completed
- set Vercel env var `OPENMHZ_API_BASE_URL=https://api.openmhz.com` for `Production` and `Preview`
- deployed to production alias: `https://franklin-safety-map.vercel.app`
- verified endpoint success:
  - `GET /api/ingest/openmhz/diagnose?system=frkoh` -> `200`, `okCount=3`
  - `GET /api/ingest/openmhz/calls?system=frkoh` -> `200` with normalized real call payload

## Why this change
- local/server-side environments were intermittently blocked (`403`) while the target host path needed to be proven
- the diagnostic route plus fetch hardening provides a repeatable, host-side truth test before committing the worker architecture to this source path

## Notes
- local worker is now pointed at `OPENMHZ_ADAPTER_BASE_URL=https://franklin-safety-map.vercel.app` in ignored `.env.local`
- worker run currently fails after ingest because STT keys are not configured locally (`XAI_API_KEY` / `OPENAI_API_KEY`)

## Validation Commands
- `npm run typecheck`
- deployed-host checks against:
  - `/api/ingest/openmhz/diagnose?system=frkoh`
  - `/api/ingest/openmhz/calls?system=frkoh`
