### PR TITLE
[codex] fix xAI STT path and ingest cursor bigint coercion

### DIFF
--- a/lib/providers/stt/xai.ts
+++ b/lib/providers/stt/xai.ts
@@ -22,14 +22,15 @@ export class XaiSpeechToTextProvider implements SpeechToTextProvider {
 
     const bytes = new Uint8Array(input.audio);
     const form = new FormData();
+    form.append("format", "true");
+    form.append("language", "en");
     form.append(
       "file",
       new Blob([bytes], { type: input.mimeType }),
       input.fileName,
     );
-    form.append("model", env.XAI_STT_MODEL);
 
-    const response = await fetch("https://api.x.ai/v1/audio/transcriptions", {
+    const response = await fetch("https://api.x.ai/v1/stt", {
       method: "POST",
       headers: {
         Authorization: `Bearer ${env.XAI_API_KEY}`,
@@ -38,7 +39,10 @@ export class XaiSpeechToTextProvider implements SpeechToTextProvider {
     });
 
     if (!response.ok) {
-      throw new Error(`xAI STT request failed with status ${response.status}`);
+      const responseBody = await response.text();
+      throw new Error(
+        `xAI STT request failed with status ${response.status}: ${responseBody.slice(0, 240)}`,
+      );
     }
 
     const payload = (await response.json()) as Record<string, unknown>;

--- a/lib/repositories/ingest-cursors.ts
+++ b/lib/repositories/ingest-cursors.ts
@@ -7,16 +7,21 @@ import { getDbPool } from "@/lib/server/db";
 type IngestCursorRow = {
   source: string;
   cursor_key: string;
-  last_occurred_at_ms: number;
+  last_occurred_at_ms: number | string;
   last_source_event_id: string | null;
   updated_at: string | Date;
 };
 
 function mapRow(row: IngestCursorRow): IngestCursor {
+  const lastOccurredAtMs =
+    typeof row.last_occurred_at_ms === "string"
+      ? Number.parseInt(row.last_occurred_at_ms, 10)
+      : row.last_occurred_at_ms;
+
   return ingestCursorSchema.parse({
     source: row.source,
     cursorKey: row.cursor_key,
-    lastOccurredAtMs: row.last_occurred_at_ms,
+    lastOccurredAtMs,
     lastSourceEventId: row.last_source_event_id,
     updatedAt:
       row.updated_at instanceof Date
@@ -103,4 +108,3 @@ export class PostgresIngestCursorRepository implements IngestCursorRepository {
 export function createIngestCursorRepository(): IngestCursorRepository {
   return new PostgresIngestCursorRepository();
 }
-


### PR DESCRIPTION
## Summary
- fix xAI STT integration to use the current xAI endpoint and multipart contract
- fix ingest cursor row mapping to coerce `last_occurred_at_ms` from Postgres bigint string to number

## Changes
- `lib/providers/stt/xai.ts`
  - switched from `POST /v1/audio/transcriptions` to `POST /v1/stt`
  - set request form fields to match xAI STT expectations (`format`, `language`, `file`)
  - improved error message to include response body preview
- `lib/repositories/ingest-cursors.ts`
  - updated `last_occurred_at_ms` row type to `number | string`
  - added safe coercion before schema parse

## Validation
- `npm run typecheck`
- local worker run now reaches xAI STT and processes live OpenMHz-derived call data end-to-end

## Security
- no API keys or secrets included in this commit/branch
