### PR TITLE
[codex] scaffold Render deployment for adapter and worker

### DIFF
--- a/docs/safety_map_milestones.md
+++ b/docs/safety_map_milestones.md
@@ -20,7 +20,7 @@ This document provides a structured execution path for the development team. The
 *Goal: Get the reliable, API-driven data onto the map.*
 
 - [ ] **Transit Layer (COTA):**
-    - [ ] Implement GTFS-Realtime parser in the Railway TypeScript worker.
+    - [ ] Implement GTFS-Realtime parser in the Render TypeScript worker.
     - [ ] Sync live bus positions to Supabase.
     - [ ] Render moving bus markers on the Mapbox UI.
 - [ ] **Traffic Layer (ODOT OHGO):**
@@ -79,4 +79,4 @@ This document provides a structured execution path for the development team. The
 - [ ] **Stress Testing:** Verify the background worker can handle peak-hour radio traffic without lagging.
 - [ ] **Accuracy Audit:** Compare AI-extracted locations against actual official reports to tune prompts.
 - [ ] **UI Polish:** Finalize the "Dark Mode" professional aesthetic.
-- [ ] **Deployment:** Final production push to Vercel/Railway.
+- [ ] **Deployment:** Final production push to Vercel/Render.

--- a/docs/safety_map_render_deployment.md
+++ b/docs/safety_map_render_deployment.md
@@ -1,0 +1,33 @@
+# Render Deployment Guide
+
+## Scope
+This project deploys two backend services on Render:
+
+1. `franklin-safety-adapter` (Web Service): serves the Next.js app and adapter routes.
+2. `franklin-safety-worker` (Background Worker): runs continuous ingest/transcribe/persist.
+
+The canonical Render blueprint is in [render.yaml](/Users/robmeyer/Projects/franklin-safety-map/render.yaml).
+
+## Deploy Steps
+
+1. Connect this repository in Render.
+2. Create services from `render.yaml` blueprint.
+3. Set required secret env vars for `franklin-safety-worker`:
+   - `OPENMHZ_ADAPTER_BASE_URL`
+   - `XAI_API_KEY`
+   - `SUPABASE_DB_URL`
+4. Optional fallback secret:
+   - `OPENAI_API_KEY`
+
+## Recommended Worker Env
+
+- `WORKER_POLL_INTERVAL_MS=10000`
+- `WORKER_ERROR_BACKOFF_MS=30000`
+- `WORKER_MAX_CALLS_PER_RUN=10`
+
+## Validation Checklist
+
+1. Adapter route is reachable:
+   - `GET /api/ingest/openmhz/calls?system=frkoh`
+2. Worker logs show processed events with incident IDs.
+3. Supabase `incidents` table receives new rows with `source=openmhz`.

--- a/docs/safety_map_tech_spec.md
+++ b/docs/safety_map_tech_spec.md
@@ -8,14 +8,14 @@ The platform is a **Hybrid Geospatial Aggregator**. It uses a TypeScript backend
 ### 2.1 The Stack
 *   **Frontend:** Next.js + Tailwind CSS + **Mapbox GL JS** $\rightarrow$ Hosted on **Vercel**.
 *   **The API Layer:** Node.js + TypeScript (Next.js Route Handlers / server APIs) $\rightarrow$ Hosted on **Vercel**.
-*   **The Engine (The Brain):** Node.js + TypeScript background workers $\rightarrow$ Hosted on **Railway.app**.
+*   **The Engine (The Brain):** Node.js + TypeScript background workers $\rightarrow$ Hosted on **Render**.
 *   **Speech-to-Text:** **xAI Speech-to-Text** as primary transcription provider, with **OpenAI STT** as fallback.
 *   **LLM Intelligence:** Accessed via hosted LLM APIs for extraction. The initial extraction path uses **Ollama Cloud API**.
 *   **Data Core:** **Supabase (PostgreSQL + PostGIS)**. PostGIS is mandatory for spatial queries.
 
 ### 2.2 Hosting Blueprint
 1.  **Vercel:** Serves the UI and lightweight API requests.
-2.  **Railway:** Runs a persistent Node.js/TypeScript worker process that never sleeps. This worker handles the "Listen, Parse, and Store" loop.
+2.  **Render:** Runs a persistent Node.js/TypeScript worker process that never sleeps. This worker handles the "Listen, Parse, and Store" loop.
 3.  **Supabase:** The central state. All workers write here; the UI reads from here.
 
 ---
@@ -31,7 +31,7 @@ This pipeline transforms hosted scanner audio into structured map markers using 
 `OpenMHz (frkoh)` $\rightarrow$ `TypeScript Polling/Fetch Worker` $\rightarrow$ `xAI STT (primary)` / `OpenAI STT (fallback)` $\rightarrow$ `Ollama Cloud Extraction` $\rightarrow$ `Supabase` $\rightarrow$ `Vercel UI`
 
 *   **Upstream Source:** The worker ingests police dispatch audio from the **OpenMHz** Franklin County system (`frkoh`).
-*   **Polling Worker:** The Railway TypeScript worker polls for newly published calls, stores a cursor (`time` + call ID), and deduplicates calls before processing.
+*   **Polling Worker:** The Render TypeScript worker polls for newly published calls, stores a cursor (`time` + call ID), and deduplicates calls before processing.
 *   **Audio Retrieval:** The worker downloads the audio for each new call. The pipeline must not assume a fixed extension such as `.wav` or `.mp3`; the upstream source may publish different audio formats.
 *   **Transcription:** Audio chunks are sent first to **xAI Speech-to-Text** for transcription. If xAI is unavailable, rate-limited, or returns low-confidence / unusable output, the worker retries with **OpenAI STT** as the fallback provider.
 *   **Entity Extraction:** The transcription is sent to **Ollama Cloud (Llama 3.1 8B)** to extract `Incident Type`, `Location`, and `Priority` in JSON format.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "worker": "tsx worker/index.ts",
+    "worker:loop": "WORKER_MODE=loop tsx worker/index.ts",
     "openmhz:diagnose": "tsx scripts/diagnose-openmhz.ts",
     "openmhz:validate-capture": "tsx scripts/validate-openmhz-capture.ts",
     "db:migrate": "tsx scripts/migrate.ts",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,53 @@
+services:
+  - type: web
+    name: franklin-safety-adapter
+    runtime: node
+    plan: starter
+    autoDeploy: true
+    buildCommand: npm ci && npm run build
+    startCommand: npm run start
+    envVars:
+      - key: NODE_VERSION
+        value: "22"
+      - key: INGEST_SOURCE
+        value: openmhz
+      - key: OPENMHZ_SYSTEM
+        value: frkoh
+      - key: OPENMHZ_API_BASE_URL
+        value: https://api.openmhz.com
+      - key: OPENMHZ_ADAPTER_MODE
+        value: direct
+      - key: OPENMHZ_POLL_LOOKBACK_MS
+        value: "5000"
+
+  - type: worker
+    name: franklin-safety-worker
+    runtime: node
+    plan: starter
+    autoDeploy: true
+    buildCommand: npm ci && npm run build
+    startCommand: npm run worker:loop
+    maxShutdownDelaySeconds: 120
+    envVars:
+      - key: NODE_VERSION
+        value: "22"
+      - key: INGEST_SOURCE
+        value: openmhz
+      - key: OPENMHZ_SYSTEM
+        value: frkoh
+      - key: OPENMHZ_ADAPTER_BASE_URL
+        sync: false
+      - key: OPENMHZ_ADAPTER_CALLS_PATH
+        value: /api/ingest/openmhz/calls
+      - key: WORKER_POLL_INTERVAL_MS
+        value: "10000"
+      - key: WORKER_ERROR_BACKOFF_MS
+        value: "30000"
+      - key: WORKER_MAX_CALLS_PER_RUN
+        value: "10"
+      - key: XAI_API_KEY
+        sync: false
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: SUPABASE_DB_URL
+        sync: false


### PR DESCRIPTION
## Summary
- add Render blueprint (`render.yaml`) for backend deployment
- add dedicated Render deployment guide for this repo
- update architecture and milestones docs to target Render instead of Railway
- add `worker:loop` script for explicit long-running worker startup command

## What this sets up
- `franklin-safety-adapter` Render web service
  - builds/runs Next.js app and adapter routes
- `franklin-safety-worker` Render background worker
  - runs `npm run worker:loop`
  - includes loop/backoff/batch env controls

## Files
- `render.yaml`
- `docs/safety_map_render_deployment.md`
- `docs/safety_map_tech_spec.md`
- `docs/safety_map_milestones.md`
- `package.json`

## Validation
- `npm run typecheck`
- `npm run build`

## Notes
- secrets remain `sync: false` in `render.yaml` and are expected to be provided in Render dashboard/workspace
