### PR TITLE
Add incident lineage and unresolved geocode handling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -72,7 +72,7 @@ a {
 
 .stats {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 12px;
   margin-top: 24px;
 }
@@ -169,6 +169,14 @@ a {
   background: var(--safe);
 }
 
+.marker-unresolved {
+  background: transparent !important;
+  border: 3px solid var(--text);
+  box-shadow:
+    0 0 0 6px rgba(255, 255, 255, 0.4),
+    inset 0 0 0 2px rgba(255, 255, 255, 0.8);
+}
+
 .incident-list {
   display: grid;
   gap: 12px;
@@ -215,6 +223,12 @@ a {
   line-height: 1.55;
 }
 
+.incident-warning {
+  margin-top: 10px !important;
+  color: var(--danger) !important;
+  font-size: 0.92rem;
+}
+
 @media (max-width: 960px) {
   .shell {
     padding: 18px;
@@ -226,7 +240,7 @@ a {
   }
 
   .stats {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr;
   }
 
   .map-placeholder {
@@ -234,3 +248,8 @@ a {
   }
 }
 
+@media (max-width: 640px) {
+  .stats {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,9 +13,10 @@ export default async function HomePage() {
       acc.total += 1;
       if (incident.layer === "police") acc.police += 1;
       if (incident.severity >= 4) acc.urgent += 1;
+      if (incident.geocoding?.resolved === false) acc.unresolved += 1;
       return acc;
     },
-    { total: 0, police: 0, urgent: 0 },
+    { total: 0, police: 0, urgent: 0, unresolved: 0 },
   );
 
   return (
@@ -46,6 +47,10 @@ export default async function HomePage() {
           <label>High / Critical</label>
           <strong>{counts.urgent}</strong>
         </article>
+        <article className="stat">
+          <label>Needs Geocode Review</label>
+          <strong>{counts.unresolved}</strong>
+        </article>
       </section>
 
       <section className="grid">
@@ -63,13 +68,13 @@ export default async function HomePage() {
             {incidents.map((incident) => (
               <span
                 key={incident.id}
-                className="marker"
+                className={`marker${incident.geocoding?.resolved === false ? " marker-unresolved" : ""}`}
                 data-severity={incident.severityLabel}
                 style={{
                   left: `${44 + (incident.point.lng + 83.1) * 60}%`,
                   top: `${56 - (incident.point.lat - 39.9) * 90}%`,
                 }}
-                title={`${incident.category} at ${incident.address}`}
+                title={`${incident.category} at ${incident.address}${incident.geocoding?.resolved === false ? " (approximate location)" : ""}`}
               />
             ))}
           </div>
@@ -93,6 +98,11 @@ export default async function HomePage() {
                 <h3>{incident.category}</h3>
                 <p>{incident.address}</p>
                 <p>{incident.description}</p>
+                {incident.geocoding?.resolved === false ? (
+                  <p className="incident-warning">
+                    Approximate map placement. Reason: {incident.geocoding.reason ?? "unresolved geocode"}.
+                  </p>
+                ) : null}
               </article>
             ))}
           </div>

--- a/lib/repositories/enrichment-runs.ts
+++ b/lib/repositories/enrichment-runs.ts
@@ -1,0 +1,116 @@
+import { getDbPool } from "@/lib/server/db";
+import {
+  enrichmentRunSchema,
+  geocodingResultSchema,
+  type EnrichmentRun,
+  type GeocodingResult,
+} from "@/lib/types/domain";
+
+type EnrichmentRunRow = {
+  id: string;
+  source_call_id: string;
+  enrichment_job_id: string | null;
+  transcript_text: string | null;
+  transcription_provider: string | null;
+  extraction: unknown;
+  geocoding: unknown;
+  outcome: string;
+  created_at: string | Date;
+};
+
+function toIsoString(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function coerceRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function mapRow(row: EnrichmentRunRow): EnrichmentRun {
+  return enrichmentRunSchema.parse({
+    id: row.id,
+    sourceCallId: row.source_call_id,
+    enrichmentJobId: row.enrichment_job_id,
+    transcriptText: row.transcript_text,
+    transcriptionProvider: row.transcription_provider,
+    extraction: coerceRecord(row.extraction),
+    geocoding: geocodingResultSchema.parse(row.geocoding),
+    outcome: row.outcome,
+    createdAt: toIsoString(row.created_at),
+  });
+}
+
+export interface EnrichmentRunRepository {
+  create(input: {
+    sourceCallId: string;
+    enrichmentJobId?: string | null;
+    transcriptText?: string | null;
+    transcriptionProvider?: string | null;
+    extraction?: Record<string, unknown>;
+    geocoding: GeocodingResult;
+    outcome: "published" | "skipped" | "failed";
+  }): Promise<EnrichmentRun>;
+}
+
+export class PostgresEnrichmentRunRepository implements EnrichmentRunRepository {
+  async create(input: {
+    sourceCallId: string;
+    enrichmentJobId?: string | null;
+    transcriptText?: string | null;
+    transcriptionProvider?: string | null;
+    extraction?: Record<string, unknown>;
+    geocoding: GeocodingResult;
+    outcome: "published" | "skipped" | "failed";
+  }): Promise<EnrichmentRun> {
+    const pool = getDbPool();
+    const result = await pool.query<EnrichmentRunRow>(
+      `
+        insert into enrichment_runs (
+          source_call_id,
+          enrichment_job_id,
+          transcript_text,
+          transcription_provider,
+          extraction,
+          geocoding,
+          outcome
+        )
+        values (
+          $1::uuid,
+          $2::uuid,
+          $3,
+          $4,
+          $5::jsonb,
+          $6::jsonb,
+          $7
+        )
+        returning
+          id,
+          source_call_id,
+          enrichment_job_id,
+          transcript_text,
+          transcription_provider,
+          extraction,
+          geocoding,
+          outcome,
+          created_at
+      `,
+      [
+        input.sourceCallId,
+        input.enrichmentJobId ?? null,
+        input.transcriptText ?? null,
+        input.transcriptionProvider ?? null,
+        JSON.stringify(input.extraction ?? {}),
+        JSON.stringify(input.geocoding),
+        input.outcome,
+      ],
+    );
+
+    return mapRow(result.rows[0]);
+  }
+}
+
+export function createEnrichmentRunRepository(): EnrichmentRunRepository {
+  return new PostgresEnrichmentRunRepository();
+}

--- a/lib/repositories/incidents.ts
+++ b/lib/repositories/incidents.ts
@@ -1,6 +1,7 @@
 import { getEnv } from "@/lib/config/env";
 import { mockIncidents } from "@/lib/repositories/mock-incidents";
 import {
+  geocodingResultSchema,
   incidentSchema,
   incidentUpsertSchema,
   mapFeedResponseSchema,
@@ -50,6 +51,7 @@ type IncidentRow = {
   updated_at: string | Date;
   lat: number;
   lng: number;
+  geocoding: unknown;
 };
 
 function severityToLabel(severity: number): Incident["severityLabel"] {
@@ -84,6 +86,10 @@ function mapRowToIncident(row: IncidentRow): Incident {
       lat: row.lat,
       lng: row.lng,
     },
+    geocoding:
+      row.geocoding && typeof row.geocoding === "object"
+        ? geocodingResultSchema.parse(row.geocoding)
+        : undefined,
   });
 }
 
@@ -101,6 +107,7 @@ export class PostgresIncidentRepository implements IncidentRepository {
         status,
         created_at,
         updated_at,
+        metadata->'geocoding' as geocoding,
         ST_Y(location::geometry) as lat,
         ST_X(location::geometry) as lng
       from incidents
@@ -120,6 +127,8 @@ export class PostgresIncidentRepository implements IncidentRepository {
         insert into incidents (
           source,
           source_event_id,
+          source_call_id,
+          enrichment_run_id,
           layer,
           category,
           address,
@@ -141,14 +150,18 @@ export class PostgresIncidentRepository implements IncidentRepository {
           $6,
           $7,
           $8,
-          $9::timestamptz,
+          $9,
+          $10,
+          $11::timestamptz,
           now(),
           now(),
-          ST_SetSRID(ST_MakePoint($10, $11), 4326)::geography,
-          $12::jsonb
+          ST_SetSRID(ST_MakePoint($12, $13), 4326)::geography,
+          $14::jsonb
         )
         on conflict (source, source_event_id)
         do update set
+          source_call_id = excluded.source_call_id,
+          enrichment_run_id = excluded.enrichment_run_id,
           layer = excluded.layer,
           category = excluded.category,
           address = excluded.address,
@@ -169,12 +182,15 @@ export class PostgresIncidentRepository implements IncidentRepository {
           status,
           created_at,
           updated_at,
+          metadata->'geocoding' as geocoding,
           ST_Y(location::geometry) as lat,
           ST_X(location::geometry) as lng
       `,
       [
         parsed.source,
         parsed.sourceEventId ?? null,
+        parsed.sourceCallId ?? null,
+        parsed.enrichmentRunId ?? null,
         parsed.layer,
         parsed.category,
         parsed.address,

--- a/lib/services/enrich-source-call.ts
+++ b/lib/services/enrich-source-call.ts
@@ -1,6 +1,8 @@
+import { createEnrichmentRunRepository } from "@/lib/repositories/enrichment-runs";
 import { createIncidentRepository } from "@/lib/repositories/incidents";
 import { createSourceCallRepository } from "@/lib/repositories/source-calls";
 import { createIncidentExtractionService } from "@/lib/services/extract-incident";
+import { createGeocodingService } from "@/lib/services/geocode";
 import {
   createTranscriptionService,
   TranscriptionFailedError,
@@ -70,7 +72,9 @@ export class SkippableEnrichmentError extends Error {
 
 type EnrichSourceCallDeps = {
   sourceCallRepository: ReturnType<typeof createSourceCallRepository>;
+  enrichmentRunRepository: ReturnType<typeof createEnrichmentRunRepository>;
   incidentRepository: ReturnType<typeof createIncidentRepository>;
+  geocodingService: ReturnType<typeof createGeocodingService>;
   transcriptionService: ReturnType<typeof createTranscriptionService>;
   extractionService: ReturnType<typeof createIncidentExtractionService>;
 };
@@ -101,17 +105,22 @@ export function shouldPublishIncident(input: {
 export class SourceCallEnrichmentService {
   constructor(private readonly deps: EnrichSourceCallDeps) {}
 
-  async enrich(sourceCallId: string): Promise<EnrichSourceCallResult> {
+  async enrich(input: {
+    sourceCallId: string;
+    enrichmentJobId?: string | null;
+  }): Promise<EnrichSourceCallResult> {
     const {
       sourceCallRepository,
+      enrichmentRunRepository,
       incidentRepository,
+      geocodingService,
       transcriptionService,
       extractionService,
     } = this.deps;
 
-    let sourceCall = await sourceCallRepository.getById(sourceCallId);
+    let sourceCall = await sourceCallRepository.getById(input.sourceCallId);
     if (!sourceCall) {
-      throw new Error(`Source call ${sourceCallId} was not found`);
+      throw new Error(`Source call ${input.sourceCallId} was not found`);
     }
 
     let transcriptText = sourceCall.transcriptText;
@@ -121,7 +130,7 @@ export class SourceCallEnrichmentService {
       if (!sourceCall.audioUrl) {
         throw new SkippableEnrichmentError(
           "missing_audio_and_transcript",
-          `Source call ${sourceCallId} has neither transcript text nor audio URL`,
+          `Source call ${input.sourceCallId} has neither transcript text nor audio URL`,
         );
       }
 
@@ -171,13 +180,41 @@ export class SourceCallEnrichmentService {
     if (!hasIncidentSignal) {
       throw new SkippableEnrichmentError(
         "low_confidence_non_incident",
-        `Source call ${sourceCallId} did not contain a strong incident signal`,
+        `Source call ${input.sourceCallId} did not contain a strong incident signal`,
       );
     }
+
+    const geocoding = await geocodingService.geocode({
+      address: incident.address,
+      locationText: incident.locationText,
+      label: sourceCall.label,
+    });
+
+    const enrichmentRun = await enrichmentRunRepository.create({
+      sourceCallId: sourceCall.id,
+      enrichmentJobId: input.enrichmentJobId ?? null,
+      transcriptText,
+      transcriptionProvider,
+      extraction: {
+        incidentType: incident.incidentType,
+        category: incident.category,
+        locationText: incident.locationText,
+        address: incident.address,
+        summary: incident.summary,
+        severity: incident.severity,
+        statusHint: incident.statusHint,
+        confidence: incident.confidence,
+        matchedCodes: incident.matchedCodes,
+      },
+      geocoding,
+      outcome: "published",
+    });
 
     const savedIncident = await incidentRepository.upsert({
       source: sourceCall.source,
       sourceEventId: sourceCall.sourceEventId,
+      sourceCallId: sourceCall.id,
+      enrichmentRunId: enrichmentRun.id,
       layer: "police",
       category: incident.category ?? "Radio Dispatch",
       address: incident.address ?? sourceCall.label ?? "Unknown location",
@@ -185,9 +222,9 @@ export class SourceCallEnrichmentService {
       severity: incident.severity,
       status: "Active",
       occurredAt: sourceCall.occurredAt,
-      point: {
-        lat: 39.9612,
-        lng: -82.9988,
+      point: geocoding.point ?? {
+        lat: 39.43,
+        lng: -84.21,
       },
       metadata: {
         channel: sourceCall.channel,
@@ -202,7 +239,7 @@ export class SourceCallEnrichmentService {
           confidence: incident.confidence,
           matchedCodes: incident.matchedCodes,
         },
-        geocoded: false,
+        geocoding,
         sourceMetadata: sourceCall.metadata,
       },
     });
@@ -224,7 +261,9 @@ export class SourceCallEnrichmentService {
 export function createSourceCallEnrichmentService(): SourceCallEnrichmentService {
   return new SourceCallEnrichmentService({
     sourceCallRepository: createSourceCallRepository(),
+    enrichmentRunRepository: createEnrichmentRunRepository(),
     incidentRepository: createIncidentRepository(),
+    geocodingService: createGeocodingService(),
     transcriptionService: createTranscriptionService(),
     extractionService: createIncidentExtractionService(),
   });

--- a/lib/services/geocode.ts
+++ b/lib/services/geocode.ts
@@ -1,0 +1,134 @@
+import { getEnv } from "@/lib/config/env";
+import { geocodingResultSchema, type GeocodingResult } from "@/lib/types/domain";
+
+const WARREN_COUNTY_CENTER = {
+  lat: 39.43,
+  lng: -84.21,
+};
+
+type GeocodeInput = {
+  address?: string | null;
+  locationText?: string | null;
+  label?: string | null;
+};
+
+function buildQuery(input: GeocodeInput): string | null {
+  const candidates = [input.address, input.locationText, input.label]
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value && value.length > 0));
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return `${candidates[0]}, Warren County, Ohio`;
+}
+
+function unresolvedResult(input: {
+  query: string | null;
+  reason: string;
+}): GeocodingResult {
+  return geocodingResultSchema.parse({
+    provider: "county_bias",
+    resolved: false,
+    confidence: 0.15,
+    query: input.query,
+    reason: input.reason,
+    point: WARREN_COUNTY_CENTER,
+  });
+}
+
+export interface GeocodingService {
+  geocode(input: GeocodeInput): Promise<GeocodingResult>;
+}
+
+export class ProviderFallbackGeocodingService implements GeocodingService {
+  async geocode(input: GeocodeInput): Promise<GeocodingResult> {
+    const query = buildQuery(input);
+    if (!query) {
+      return unresolvedResult({
+        query: null,
+        reason: "missing_location_text",
+      });
+    }
+
+    const env = getEnv();
+    if (!env.MAPBOX_ACCESS_TOKEN) {
+      return unresolvedResult({
+        query,
+        reason: "mapbox_unconfigured",
+      });
+    }
+
+    const url = new URL(
+      `https://api.mapbox.com/search/geocode/v6/forward`,
+    );
+    url.searchParams.set("q", query);
+    url.searchParams.set("access_token", env.MAPBOX_ACCESS_TOKEN);
+    url.searchParams.set("limit", "1");
+    url.searchParams.set("country", "US");
+    url.searchParams.set("types", "address,street,place,locality,neighborhood");
+
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+      },
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      return unresolvedResult({
+        query,
+        reason: `mapbox_http_${response.status}`,
+      });
+    }
+
+    const payload = (await response.json()) as {
+      features?: Array<{
+        properties?: {
+          coordinates?: {
+            latitude?: number;
+            longitude?: number;
+          };
+          match_code?: {
+            confidence?: string;
+          };
+        };
+      }>;
+    };
+
+    const feature = payload.features?.[0];
+    const lat = feature?.properties?.coordinates?.latitude;
+    const lng = feature?.properties?.coordinates?.longitude;
+
+    if (typeof lat !== "number" || typeof lng !== "number") {
+      return unresolvedResult({
+        query,
+        reason: "mapbox_no_result",
+      });
+    }
+
+    const matchConfidence = feature?.properties?.match_code?.confidence;
+    const confidence =
+      matchConfidence === "exact"
+        ? 0.95
+        : matchConfidence === "high"
+          ? 0.85
+          : matchConfidence === "medium"
+            ? 0.7
+            : 0.55;
+
+    return geocodingResultSchema.parse({
+      provider: "mapbox",
+      resolved: true,
+      confidence,
+      query,
+      reason: null,
+      point: { lat, lng },
+    });
+  }
+}
+
+export function createGeocodingService(): GeocodingService {
+  return new ProviderFallbackGeocodingService();
+}

--- a/lib/types/domain.ts
+++ b/lib/types/domain.ts
@@ -23,6 +23,7 @@ export const incidentSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   point: pointSchema,
+  geocoding: z.lazy(() => geocodingResultSchema).optional(),
 });
 
 export type Incident = z.infer<typeof incidentSchema>;
@@ -118,6 +119,39 @@ export const enrichmentJobSchema = z.object({
 
 export type EnrichmentJob = z.infer<typeof enrichmentJobSchema>;
 
+export const enrichmentRunOutcomeSchema = z.enum([
+  "published",
+  "skipped",
+  "failed",
+]);
+
+export type EnrichmentRunOutcome = z.infer<typeof enrichmentRunOutcomeSchema>;
+
+export const geocodingResultSchema = z.object({
+  provider: z.string(),
+  resolved: z.boolean(),
+  confidence: z.number().min(0).max(1),
+  query: z.string().nullable(),
+  reason: z.string().nullable(),
+  point: pointSchema.nullable(),
+});
+
+export type GeocodingResult = z.infer<typeof geocodingResultSchema>;
+
+export const enrichmentRunSchema = z.object({
+  id: z.string().uuid(),
+  sourceCallId: z.string().uuid(),
+  enrichmentJobId: z.string().uuid().nullable(),
+  transcriptText: z.string().nullable(),
+  transcriptionProvider: z.string().nullable(),
+  extraction: z.record(z.string(), z.unknown()).default({}),
+  geocoding: geocodingResultSchema,
+  outcome: enrichmentRunOutcomeSchema,
+  createdAt: z.string(),
+});
+
+export type EnrichmentRun = z.infer<typeof enrichmentRunSchema>;
+
 export const transcriptionSchema = z.object({
   provider: z.enum(["whisper_local", "xai", "openai"]),
   text: z.string(),
@@ -154,6 +188,8 @@ export type ExtractedIncident = z.infer<typeof extractedIncidentSchema>;
 export const incidentUpsertSchema = z.object({
   source: z.string(),
   sourceEventId: z.string().nullable().optional(),
+  sourceCallId: z.string().uuid().nullable().optional(),
+  enrichmentRunId: z.string().uuid().nullable().optional(),
   layer: layerSchema,
   category: z.string(),
   address: z.string(),

--- a/sql/migrations/006_enrichment_runs.sql
+++ b/sql/migrations/006_enrichment_runs.sql
@@ -1,0 +1,17 @@
+create table if not exists enrichment_runs (
+  id uuid primary key default gen_random_uuid(),
+  source_call_id uuid not null references source_calls(id) on delete cascade,
+  enrichment_job_id uuid references enrichment_jobs(id) on delete set null,
+  transcript_text text,
+  transcription_provider text,
+  extraction jsonb not null default '{}'::jsonb,
+  geocoding jsonb not null default '{}'::jsonb,
+  outcome text not null check (outcome in ('published', 'skipped', 'failed')),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists enrichment_runs_source_call_idx
+  on enrichment_runs (source_call_id, created_at desc);
+
+create index if not exists enrichment_runs_job_idx
+  on enrichment_runs (enrichment_job_id);

--- a/sql/migrations/007_incidents_lineage.sql
+++ b/sql/migrations/007_incidents_lineage.sql
@@ -1,0 +1,9 @@
+alter table incidents
+  add column if not exists source_call_id uuid references source_calls(id) on delete set null,
+  add column if not exists enrichment_run_id uuid references enrichment_runs(id) on delete set null;
+
+create index if not exists incidents_source_call_idx
+  on incidents (source_call_id);
+
+create index if not exists incidents_enrichment_run_idx
+  on incidents (enrichment_run_id);

--- a/worker/enrich.ts
+++ b/worker/enrich.ts
@@ -1,10 +1,13 @@
 import { getEnv } from "@/lib/config/env";
 import { createEnrichmentJobRepository } from "@/lib/repositories/enrichment-jobs";
+import { createEnrichmentRunRepository } from "@/lib/repositories/enrichment-runs";
+import { createSourceCallRepository } from "@/lib/repositories/source-calls";
 import { closeDbPool } from "@/lib/server/db";
 import {
   createSourceCallEnrichmentService,
   SkippableEnrichmentError,
 } from "@/lib/services/enrich-source-call";
+import { geocodingResultSchema } from "@/lib/types/domain";
 
 const DEFAULT_JOB_TYPE = "incident_enrichment";
 const DEFAULT_WORKER_ID = `enrich-${process.pid}`;
@@ -17,12 +20,16 @@ function sleep(ms: number): Promise<void> {
 
 type WorkerDeps = {
   enrichmentJobRepository: ReturnType<typeof createEnrichmentJobRepository>;
+  enrichmentRunRepository: ReturnType<typeof createEnrichmentRunRepository>;
+  sourceCallRepository: ReturnType<typeof createSourceCallRepository>;
   sourceCallEnrichmentService: ReturnType<typeof createSourceCallEnrichmentService>;
 };
 
 function createWorkerDeps(): WorkerDeps {
   return {
     enrichmentJobRepository: createEnrichmentJobRepository(),
+    enrichmentRunRepository: createEnrichmentRunRepository(),
+    sourceCallRepository: createSourceCallRepository(),
     sourceCallEnrichmentService: createSourceCallEnrichmentService(),
   };
 }
@@ -38,7 +45,10 @@ async function processNextJob(deps: WorkerDeps, workerId: string): Promise<boole
   }
 
   try {
-    const result = await deps.sourceCallEnrichmentService.enrich(job.sourceCallId);
+    const result = await deps.sourceCallEnrichmentService.enrich({
+      sourceCallId: job.sourceCallId,
+      enrichmentJobId: job.id,
+    });
     await deps.enrichmentJobRepository.markCompleted(job.id);
 
     console.log(
@@ -58,6 +68,28 @@ async function processNextJob(deps: WorkerDeps, workerId: string): Promise<boole
     );
   } catch (error) {
     if (error instanceof SkippableEnrichmentError) {
+      const sourceCall = await deps.sourceCallRepository.getById(job.sourceCallId);
+      if (sourceCall) {
+        await deps.enrichmentRunRepository.create({
+          sourceCallId: sourceCall.id,
+          enrichmentJobId: job.id,
+          transcriptText: sourceCall.transcriptText,
+          transcriptionProvider: null,
+          extraction: {
+            skippedReason: error.reason,
+          },
+          geocoding: geocodingResultSchema.parse({
+            provider: "none",
+            resolved: false,
+            confidence: 0,
+            query: null,
+            reason: error.reason,
+            point: null,
+          }),
+          outcome: "skipped",
+        });
+      }
+
       await deps.enrichmentJobRepository.markCompleted(job.id);
       console.log(
         JSON.stringify({


### PR DESCRIPTION
## Summary
- add enrichment run storage and incident lineage columns so published incidents remain traceable back to the raw call and enrichment pass
- add a geocoding service abstraction and store explicit geocoding metadata instead of silently using the old Columbus placeholder point
- surface unresolved geocodes in the frontend with a review count, approximate marker styling, and incident-card warnings

## Verification
- `npm run typecheck`
- `npm test`
- `npm run db:migrate`
- reran a known-good enrichment job and verified `enrichment_runs`, `incidents.source_call_id`, `incidents.enrichment_run_id`, and unresolved geocoding metadata in Supabase
