### PR TITLE
[codex] Add extraction evaluation harness

### DIFF
--- a/data/evaluation/warren-county-extraction.sample.json
+++ b/data/evaluation/warren-county-extraction.sample.json
@@ -1,0 +1,91 @@
+{
+  "name": "warren-county-extraction-sample",
+  "description": "Small labeled Warren County dispatch evaluation set for extraction, publish, location, and review metrics.",
+  "items": [
+    {
+      "id": "wc-sample-001",
+      "source": "openmhz",
+      "sourceEventId": "sample-structure-fire",
+      "occurredAt": "2026-04-21T12:00:00.000Z",
+      "transcript": "Station 16, request mutual aid for a ladder at 10406 Brentwood Pike Apartment 216 for a structure fire.",
+      "channel": "frkoh",
+      "label": "10406 Brentwood Pike",
+      "expected": {
+        "publish": true,
+        "category": "Structure Fire",
+        "incidentType": "Structure Fire",
+        "severity": 5,
+        "locationText": "10406 Brentwood Pike",
+        "needsReview": true
+      }
+    },
+    {
+      "id": "wc-sample-002",
+      "source": "openmhz",
+      "sourceEventId": "sample-bank-theft",
+      "occurredAt": "2026-04-21T12:05:00.000Z",
+      "transcript": "8101 Waynesboro needs to file a report reference bank theft.",
+      "channel": "frkoh",
+      "label": "8101 Waynesboro",
+      "expected": {
+        "publish": true,
+        "category": "Theft",
+        "incidentType": "Theft",
+        "severity": 2,
+        "locationText": "8101 Waynesboro",
+        "needsReview": true
+      }
+    },
+    {
+      "id": "wc-sample-003",
+      "source": "openmhz",
+      "sourceEventId": "sample-missing-person",
+      "occurredAt": "2026-04-21T12:10:00.000Z",
+      "transcript": "2 0 31, a missing person, West Laurel Spring Drive, Beckworth.",
+      "channel": "frkoh",
+      "label": "West Laurel Spring Drive",
+      "expected": {
+        "publish": true,
+        "category": "Missing Person",
+        "incidentType": "Missing Person",
+        "severity": 4,
+        "locationText": "West Laurel Spring Drive",
+        "needsReview": true
+      }
+    },
+    {
+      "id": "wc-sample-004",
+      "source": "openmhz",
+      "sourceEventId": "sample-unit-clear",
+      "occurredAt": "2026-04-21T12:15:00.000Z",
+      "transcript": "13 York Clear 22 54.",
+      "channel": "frkoh",
+      "label": null,
+      "expected": {
+        "publish": false,
+        "category": null,
+        "incidentType": null,
+        "severity": null,
+        "locationText": null,
+        "needsReview": true
+      }
+    },
+    {
+      "id": "wc-sample-005",
+      "source": "openmhz",
+      "sourceEventId": "sample-unit-traffic",
+      "occurredAt": "2026-04-21T12:20:00.000Z",
+      "transcript": "2 Lincoln 32 SF non-active 81 41 Waynesboro.",
+      "channel": "frkoh",
+      "label": "Waynesboro",
+      "expected": {
+        "publish": false,
+        "category": null,
+        "incidentType": null,
+        "severity": null,
+        "locationText": null,
+        "needsReview": true
+      }
+    }
+  ]
+}

--- a/docs/safety_map_replay_runbook.md
+++ b/docs/safety_map_replay_runbook.md
@@ -74,6 +74,79 @@ npm run db:reenqueue -- --ids 550e8400-e29b-41d4-a716-446655440000,660e8400-e29b
 
 ---
 
+## Evaluating Extraction Quality
+
+Use the evaluation harness before promoting prompt, model, codebook, geocoder, or audit changes into UAT.
+
+```bash
+npm run eval:extraction -- --provider heuristic --pretty
+```
+
+By default this reads:
+
+```text
+data/evaluation/warren-county-extraction.sample.json
+```
+
+The report is JSON and includes:
+
+| Metric | Meaning |
+|---|---|
+| `publishPrecision` | Published calls that were expected to publish |
+| `falsePositiveRate` | Expected skips that were incorrectly published |
+| `skipRate` | Share of calls skipped or suppressed by extraction/audit logic |
+| `locationExtractionAccuracy` | Labeled location text matched by extracted location/address |
+| `categoryAccuracy` | Labeled category/incident type matched by extraction |
+| `severityAccuracy` | Labeled severity matched by extraction |
+| `reviewRate` | Share of calls marked for review |
+| `escalationRate` | Share of calls routed through audited publish or suppression |
+| `suppressedRate` | Share of calls suppressed by the auditor |
+
+### Compare Prompt or Model Versions
+
+```bash
+npm run eval:extraction -- \
+  --provider ollama \
+  --prompt-version v2 \
+  --model llama3.1:8b \
+  --output reports/eval-v2.json \
+  --pretty
+```
+
+The output records `promptVersion`, `model`, `generatedAt`, and per-call results so two runs can be diffed with normal JSON tooling.
+
+### Evaluate Historical `source_calls`
+
+The harness can replay historical transcripts directly from `source_calls` without calling upstream adapters, enqueueing jobs, or writing incidents:
+
+```bash
+npm run eval:extraction -- \
+  --provider heuristic \
+  --source openmhz \
+  --since 2026-04-01T00:00:00Z \
+  --until 2026-04-02T00:00:00Z \
+  --limit 100 \
+  --output reports/eval-openmhz-2026-04-01.json \
+  --pretty
+```
+
+When a historical row matches an item in the labels file by `sourceCallId` or `sourceEventId`, that label is used. Otherwise the row is treated as expected publish by default, which is useful for operational smoke checks but should not replace a curated labeled set for precision/false-positive measurement.
+
+### Maintaining Labels
+
+Add reviewed Warren County examples to the evaluation JSON with:
+
+- transcript and source identifiers
+- expected publish/skip decision
+- expected category or incident type
+- expected severity when known
+- expected location text when present
+- expected review state when known
+
+Keep the labeled set small enough to run quickly, but include known misses, false positives, unresolved locations, high-risk calls, and routine unit/status traffic.
+
+---
+
 ## Running the Enrichment Worker
 
 The worker processes jobs from the `enrichment_jobs` queue.

--- a/lib/services/evaluate-extraction.ts
+++ b/lib/services/evaluate-extraction.ts
@@ -1,0 +1,447 @@
+import { z } from "zod";
+
+import type { IncidentAuditService } from "@/lib/services/audit-incident";
+import { shouldPublishIncident } from "@/lib/services/enrich-source-call";
+import type { IncidentExtractionService } from "@/lib/services/extract-incident";
+import type { GeocodingService } from "@/lib/services/geocode";
+import type {
+  AuditRoute,
+  ExtractedIncident,
+  ExtractionMetadata,
+  GeocodingResult,
+  PublishDecision,
+} from "@/lib/types/domain";
+
+export const evaluationExpectedSchema = z.object({
+  publish: z.boolean(),
+  category: z.string().nullable().optional(),
+  incidentType: z.string().nullable().optional(),
+  severity: z.number().int().min(1).max(5).nullable().optional(),
+  locationText: z.string().nullable().optional(),
+  needsReview: z.boolean().nullable().optional(),
+});
+
+export const evaluationItemSchema = z.object({
+  id: z.string(),
+  source: z.string().default("openmhz"),
+  sourceCallId: z.string().nullable().optional(),
+  sourceEventId: z.string().nullable().optional(),
+  occurredAt: z.string().nullable().optional(),
+  transcript: z.string().min(1),
+  channel: z.string().nullable().optional(),
+  label: z.string().nullable().optional(),
+  expected: evaluationExpectedSchema,
+});
+
+export const evaluationDatasetSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  items: z.array(evaluationItemSchema).min(1),
+});
+
+export type EvaluationExpected = z.infer<typeof evaluationExpectedSchema>;
+export type EvaluationItem = z.infer<typeof evaluationItemSchema>;
+export type EvaluationDataset = z.infer<typeof evaluationDatasetSchema>;
+
+export type EvaluationItemResult = {
+  id: string;
+  source: string;
+  sourceCallId: string | null;
+  sourceEventId: string | null;
+  expectedPublish: boolean;
+  predictedPublish: boolean;
+  outcome: "published" | "skipped" | "suppressed";
+  route: AuditRoute | "skipped_no_incident_signal";
+  correctPublishDecision: boolean;
+  categoryMatch: boolean | null;
+  severityMatch: boolean | null;
+  locationMatch: boolean | null;
+  reviewMatch: boolean | null;
+  predicted: {
+    category: string | null;
+    incidentType: string | null;
+    severity: number;
+    confidence: number;
+    needsReview: boolean;
+    locationText: string | null;
+    address: string | null;
+    geocoding: GeocodingResult | null;
+    publishDecision: PublishDecision | null;
+    extractionMetadata: ExtractionMetadata;
+  };
+};
+
+export type EvaluationMetrics = {
+  total: number;
+  expectedPublishCount: number;
+  expectedSkipCount: number;
+  predictedPublishCount: number;
+  predictedSkipCount: number;
+  truePositive: number;
+  falsePositive: number;
+  trueNegative: number;
+  falseNegative: number;
+  publishPrecision: number | null;
+  falsePositiveRate: number | null;
+  skipRate: number;
+  locationExtractionAccuracy: number | null;
+  categoryAccuracy: number | null;
+  severityAccuracy: number | null;
+  reviewRate: number;
+  reviewAccuracy: number | null;
+  escalationRate: number;
+  suppressedRate: number;
+};
+
+export type EvaluationRunInfo = {
+  datasetName: string;
+  generatedAt: string;
+  source: string | null;
+  since: string | null;
+  until: string | null;
+  promptVersion: string | null;
+  model: string | null;
+};
+
+export type EvaluationReport = {
+  run: EvaluationRunInfo;
+  metrics: EvaluationMetrics;
+  results: EvaluationItemResult[];
+};
+
+export type EvaluateExtractionDeps = {
+  extractionService: IncidentExtractionService;
+  geocodingService: GeocodingService;
+  auditService: IncidentAuditService;
+};
+
+function normalizeText(value: string | null | undefined): string | null {
+  const normalized = value
+    ?.trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return normalized && normalized.length > 0 ? normalized : null;
+}
+
+function nullableRate(numerator: number, denominator: number): number | null {
+  if (denominator === 0) return null;
+  return Number((numerator / denominator).toFixed(4));
+}
+
+function requiredRate(numerator: number, denominator: number): number {
+  if (denominator === 0) return 0;
+  return Number((numerator / denominator).toFixed(4));
+}
+
+function textMatches(
+  actual: string | null | undefined,
+  expected: string | null | undefined,
+): boolean | null {
+  const normalizedActual = normalizeText(actual);
+  const normalizedExpected = normalizeText(expected);
+
+  if (!normalizedExpected) {
+    return null;
+  }
+
+  if (!normalizedActual) {
+    return false;
+  }
+
+  return (
+    normalizedActual.includes(normalizedExpected) ||
+    normalizedExpected.includes(normalizedActual)
+  );
+}
+
+function categoryMatches(
+  actualCategory: string | null,
+  actualIncidentType: string | null,
+  expected: EvaluationExpected,
+): boolean | null {
+  const expectedCategory = normalizeText(expected.category ?? expected.incidentType);
+  if (!expectedCategory) {
+    return null;
+  }
+
+  return (
+    normalizeText(actualCategory) === expectedCategory ||
+    normalizeText(actualIncidentType) === expectedCategory
+  );
+}
+
+function routeToOutcome(input: {
+  hasIncidentSignal: boolean;
+  publishDecision: PublishDecision | null;
+}): EvaluationItemResult["outcome"] {
+  if (!input.hasIncidentSignal) {
+    return "skipped";
+  }
+
+  if (input.publishDecision?.publishable) {
+    return "published";
+  }
+
+  return "suppressed";
+}
+
+function buildSkippedDecision(input: {
+  item: EvaluationItem;
+  incident: ExtractedIncident;
+  metadata: ExtractionMetadata;
+}): EvaluationItemResult {
+  const categoryMatch = categoryMatches(
+    input.incident.category,
+    input.incident.incidentType,
+    input.item.expected,
+  );
+  const severityMatch =
+    input.item.expected.severity == null
+      ? null
+      : input.incident.severity === input.item.expected.severity;
+  const locationMatch = textMatches(
+    input.incident.locationText ?? input.incident.address,
+    input.item.expected.locationText,
+  );
+  const predictedPublish = false;
+
+  return {
+    id: input.item.id,
+    source: input.item.source,
+    sourceCallId: input.item.sourceCallId ?? null,
+    sourceEventId: input.item.sourceEventId ?? null,
+    expectedPublish: input.item.expected.publish,
+    predictedPublish,
+    outcome: "skipped",
+    route: "skipped_no_incident_signal",
+    correctPublishDecision: predictedPublish === input.item.expected.publish,
+    categoryMatch,
+    severityMatch,
+    locationMatch,
+    reviewMatch:
+      input.item.expected.needsReview == null
+        ? null
+        : input.incident.needsReview === input.item.expected.needsReview,
+    predicted: {
+      category: input.incident.category,
+      incidentType: input.incident.incidentType,
+      severity: input.incident.severity,
+      confidence: input.incident.confidence,
+      needsReview: input.incident.needsReview,
+      locationText: input.incident.locationText,
+      address: input.incident.address,
+      geocoding: null,
+      publishDecision: null,
+      extractionMetadata: input.metadata,
+    },
+  };
+}
+
+function buildAuditedResult(input: {
+  item: EvaluationItem;
+  incident: ExtractedIncident;
+  metadata: ExtractionMetadata;
+  geocoding: GeocodingResult;
+  publishDecision: PublishDecision;
+}): EvaluationItemResult {
+  const finalIncident = {
+    ...input.incident,
+    confidence: input.publishDecision.finalConfidence,
+    needsReview: input.publishDecision.needsReview,
+  };
+  const predictedPublish = input.publishDecision.publishable;
+  const predictedNeedsReview =
+    input.publishDecision.needsReview ||
+    input.publishDecision.route === "audited_publish";
+
+  return {
+    id: input.item.id,
+    source: input.item.source,
+    sourceCallId: input.item.sourceCallId ?? null,
+    sourceEventId: input.item.sourceEventId ?? null,
+    expectedPublish: input.item.expected.publish,
+    predictedPublish,
+    outcome: routeToOutcome({
+      hasIncidentSignal: true,
+      publishDecision: input.publishDecision,
+    }),
+    route: input.publishDecision.route,
+    correctPublishDecision: predictedPublish === input.item.expected.publish,
+    categoryMatch: categoryMatches(
+      finalIncident.category,
+      finalIncident.incidentType,
+      input.item.expected,
+    ),
+    severityMatch:
+      input.item.expected.severity == null
+        ? null
+        : finalIncident.severity === input.item.expected.severity,
+    locationMatch: textMatches(
+      finalIncident.locationText ?? finalIncident.address,
+      input.item.expected.locationText,
+    ),
+    reviewMatch:
+      input.item.expected.needsReview == null
+        ? null
+        : predictedNeedsReview === input.item.expected.needsReview,
+    predicted: {
+      category: finalIncident.category,
+      incidentType: finalIncident.incidentType,
+      severity: finalIncident.severity,
+      confidence: finalIncident.confidence,
+      needsReview: finalIncident.needsReview,
+      locationText: finalIncident.locationText,
+      address: finalIncident.address,
+      geocoding: input.geocoding,
+      publishDecision: input.publishDecision,
+      extractionMetadata: input.metadata,
+    },
+  };
+}
+
+function countMatches(
+  results: EvaluationItemResult[],
+  key: "categoryMatch" | "severityMatch" | "locationMatch" | "reviewMatch",
+): { matches: number; total: number } {
+  const scoped = results
+    .map((result) => result[key])
+    .filter((value): value is boolean => value !== null);
+
+  return {
+    matches: scoped.filter(Boolean).length,
+    total: scoped.length,
+  };
+}
+
+export function computeEvaluationMetrics(
+  results: EvaluationItemResult[],
+): EvaluationMetrics {
+  const total = results.length;
+  const expectedPublishCount = results.filter((result) => result.expectedPublish).length;
+  const expectedSkipCount = total - expectedPublishCount;
+  const predictedPublishCount = results.filter((result) => result.predictedPublish).length;
+  const predictedSkipCount = total - predictedPublishCount;
+  const truePositive = results.filter(
+    (result) => result.expectedPublish && result.predictedPublish,
+  ).length;
+  const falsePositive = results.filter(
+    (result) => !result.expectedPublish && result.predictedPublish,
+  ).length;
+  const trueNegative = results.filter(
+    (result) => !result.expectedPublish && !result.predictedPublish,
+  ).length;
+  const falseNegative = results.filter(
+    (result) => result.expectedPublish && !result.predictedPublish,
+  ).length;
+  const category = countMatches(results, "categoryMatch");
+  const severity = countMatches(results, "severityMatch");
+  const location = countMatches(results, "locationMatch");
+  const review = countMatches(results, "reviewMatch");
+
+  return {
+    total,
+    expectedPublishCount,
+    expectedSkipCount,
+    predictedPublishCount,
+    predictedSkipCount,
+    truePositive,
+    falsePositive,
+    trueNegative,
+    falseNegative,
+    publishPrecision: nullableRate(truePositive, truePositive + falsePositive),
+    falsePositiveRate: nullableRate(falsePositive, falsePositive + trueNegative),
+    skipRate: requiredRate(predictedSkipCount, total),
+    locationExtractionAccuracy: nullableRate(location.matches, location.total),
+    categoryAccuracy: nullableRate(category.matches, category.total),
+    severityAccuracy: nullableRate(severity.matches, severity.total),
+    reviewRate: requiredRate(
+      results.filter((result) => result.predicted.needsReview).length,
+      total,
+    ),
+    reviewAccuracy: nullableRate(review.matches, review.total),
+    escalationRate: requiredRate(
+      results.filter(
+        (result) =>
+          result.route === "audited_publish" || result.route === "suppressed",
+      ).length,
+      total,
+    ),
+    suppressedRate: requiredRate(
+      results.filter((result) => result.route === "suppressed").length,
+      total,
+    ),
+  };
+}
+
+export async function evaluateExtractionDataset(input: {
+  dataset: EvaluationDataset;
+  deps: EvaluateExtractionDeps;
+  run: Omit<EvaluationRunInfo, "datasetName" | "generatedAt"> & {
+    generatedAt?: string;
+  };
+}): Promise<EvaluationReport> {
+  const dataset = evaluationDatasetSchema.parse(input.dataset);
+  const results: EvaluationItemResult[] = [];
+
+  for (const item of dataset.items) {
+    const extraction = await input.deps.extractionService.extractFromTranscript({
+      transcript: item.transcript,
+      channel: item.channel ?? null,
+      label: item.label ?? null,
+    });
+    const incident = extraction.incident;
+    const hasIncidentSignal = shouldPublishIncident({
+      incidentType: incident.incidentType,
+      matchedCodes: incident.matchedCodes,
+    });
+
+    if (!hasIncidentSignal) {
+      results.push(
+        buildSkippedDecision({
+          item,
+          incident,
+          metadata: extraction.metadata,
+        }),
+      );
+      continue;
+    }
+
+    const geocoding = await input.deps.geocodingService.geocode({
+      address: incident.address,
+      locationText: incident.locationText,
+      label: item.label ?? null,
+    });
+    const publishDecision = input.deps.auditService.review({
+      incident,
+      geocoding,
+      extractionMetadata: extraction.metadata,
+    });
+
+    results.push(
+      buildAuditedResult({
+        item,
+        incident,
+        metadata: extraction.metadata,
+        geocoding,
+        publishDecision,
+      }),
+    );
+  }
+
+  return {
+    run: {
+      datasetName: dataset.name,
+      generatedAt: input.run.generatedAt ?? new Date().toISOString(),
+      source: input.run.source,
+      since: input.run.since,
+      until: input.run.until,
+      promptVersion: input.run.promptVersion,
+      model: input.run.model,
+    },
+    metrics: computeEvaluationMetrics(results),
+    results,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "openmhz:validate-capture": "tsx scripts/validate-openmhz-capture.ts",
     "db:migrate": "tsx scripts/migrate.ts",
     "db:seed": "tsx scripts/seed-mock-incidents.ts",
-    "db:reenqueue": "tsx scripts/reenqueue.ts"
+    "db:reenqueue": "tsx scripts/reenqueue.ts",
+    "eval:extraction": "tsx scripts/evaluate-extraction.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.80.0",

--- a/scripts/evaluate-extraction.ts
+++ b/scripts/evaluate-extraction.ts
@@ -1,0 +1,287 @@
+/**
+ * scripts/evaluate-extraction.ts
+ *
+ * Runs extraction, geocoding, and audit decisions against a labeled evaluation
+ * set or historical source_calls rows. The script is read-only: it does not
+ * enqueue jobs, write enrichment_runs, or upsert incidents.
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import { parseArgs } from "node:util";
+
+import { getEnv, resetEnvCache } from "../lib/config/env";
+import { closeDbPool, getDbPool } from "../lib/server/db";
+import { createIncidentAuditService } from "../lib/services/audit-incident";
+import { createIncidentExtractionService } from "../lib/services/extract-incident";
+import {
+  evaluateExtractionDataset,
+  evaluationDatasetSchema,
+  type EvaluationDataset,
+  type EvaluationExpected,
+  type EvaluationItem,
+} from "../lib/services/evaluate-extraction";
+import { createGeocodingService } from "../lib/services/geocode";
+
+const DEFAULT_LABELS_PATH = "data/evaluation/warren-county-extraction.sample.json";
+
+type CliOptions = {
+  labels?: string;
+  source?: string;
+  since?: string;
+  until?: string;
+  limit?: string;
+  output?: string;
+  provider?: string;
+  "prompt-version"?: string;
+  model?: string;
+  pretty: boolean;
+  help: boolean;
+};
+
+type SourceCallEvalRow = {
+  id: string;
+  source: string;
+  source_event_id: string;
+  occurred_at: string | Date;
+  transcript_text: string;
+  channel: string | null;
+  label: string | null;
+};
+
+function usage(): string {
+  return [
+    "Usage:",
+    "  npm run eval:extraction -- [options]",
+    "",
+    "Modes:",
+    "  Fixture mode (default): read labeled transcripts from --labels",
+    "  DB mode: add --source, --since, or --until to read historical source_calls",
+    "",
+    "Options:",
+    `  --labels <path>           Labeled dataset JSON (${DEFAULT_LABELS_PATH})`,
+    "  --source <source>         Filter source_calls by source, e.g. openmhz",
+    "  --since <ISO>             Include calls at or after this timestamp",
+    "  --until <ISO>             Include calls before this timestamp",
+    "  --limit <N>               Maximum DB calls to evaluate",
+    "  --provider <value>        Override extraction provider: auto, heuristic, or ollama",
+    "  --prompt-version <value>  Override EXTRACTION_PROMPT_VERSION for this run",
+    "  --model <value>           Override OLLAMA_MODEL for this run",
+    "  --output <path>           Write report JSON to a file instead of stdout",
+    "  --pretty                  Pretty-print JSON output",
+    "  --help                    Show this help",
+  ].join("\n");
+}
+
+function parseCliOptions(): CliOptions {
+  const { values } = parseArgs({
+    options: {
+      labels: { type: "string", default: DEFAULT_LABELS_PATH },
+      source: { type: "string" },
+      since: { type: "string" },
+      until: { type: "string" },
+      limit: { type: "string" },
+      output: { type: "string" },
+      provider: { type: "string" },
+      "prompt-version": { type: "string" },
+      model: { type: "string" },
+      pretty: { type: "boolean", default: false },
+      help: { type: "boolean", default: false },
+    },
+    allowPositionals: false,
+  });
+
+  return values as CliOptions;
+}
+
+function parseLimit(value: string | undefined): number | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("--limit must be a positive integer");
+  }
+
+  return parsed;
+}
+
+function isDbMode(opts: CliOptions): boolean {
+  return Boolean(opts.source || opts.since || opts.until);
+}
+
+function applyProviderOverride(provider: string | undefined): void {
+  if (!provider) {
+    return;
+  }
+
+  if (!["auto", "heuristic", "ollama"].includes(provider)) {
+    throw new Error("--provider must be one of: auto, heuristic, ollama");
+  }
+
+  process.env.INCIDENT_EXTRACTION_PROVIDER = provider;
+}
+
+async function readEvaluationDataset(path: string): Promise<EvaluationDataset> {
+  const raw = await readFile(path, "utf8");
+  return evaluationDatasetSchema.parse(JSON.parse(raw));
+}
+
+function labelKey(item: EvaluationItem): string[] {
+  return [
+    item.sourceCallId ? `id:${item.sourceCallId}` : "",
+    item.sourceEventId ? `event:${item.sourceEventId}` : "",
+  ].filter(Boolean);
+}
+
+function buildExpectedIndex(
+  dataset: EvaluationDataset,
+): Map<string, EvaluationExpected> {
+  const index = new Map<string, EvaluationExpected>();
+  for (const item of dataset.items) {
+    for (const key of labelKey(item)) {
+      index.set(key, item.expected);
+    }
+  }
+
+  return index;
+}
+
+function toIsoString(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+async function loadDbDataset(input: {
+  labelDataset: EvaluationDataset;
+  source?: string;
+  since?: string;
+  until?: string;
+  limit: number | null;
+}): Promise<EvaluationDataset> {
+  const pool = getDbPool();
+  const conditions = ["transcript_text is not null", "btrim(transcript_text) <> ''"];
+  const params: unknown[] = [];
+
+  if (input.source) {
+    params.push(input.source);
+    conditions.push(`source = $${params.length}`);
+  }
+
+  if (input.since) {
+    params.push(input.since);
+    conditions.push(`occurred_at >= $${params.length}::timestamptz`);
+  }
+
+  if (input.until) {
+    params.push(input.until);
+    conditions.push(`occurred_at < $${params.length}::timestamptz`);
+  }
+
+  params.push(input.limit);
+  const limitParam = params.length;
+  const query = `
+    select
+      id,
+      source,
+      source_event_id,
+      occurred_at,
+      transcript_text,
+      channel,
+      label
+    from source_calls
+    where ${conditions.join(" and ")}
+    order by occurred_at asc, id asc
+    limit coalesce($${limitParam}::integer, 2147483647)
+  `;
+  const result = await pool.query<SourceCallEvalRow>(query, params);
+  const expectedByKey = buildExpectedIndex(input.labelDataset);
+
+  return evaluationDatasetSchema.parse({
+    name: `${input.labelDataset.name}:source_calls`,
+    description: "Historical source_calls evaluation slice",
+    items: result.rows.map((row) => {
+      const expected =
+        expectedByKey.get(`id:${row.id}`) ??
+        expectedByKey.get(`event:${row.source_event_id}`) ??
+        { publish: true };
+
+      return {
+        id: row.id,
+        source: row.source,
+        sourceCallId: row.id,
+        sourceEventId: row.source_event_id,
+        occurredAt: toIsoString(row.occurred_at),
+        transcript: row.transcript_text,
+        channel: row.channel,
+        label: row.label,
+        expected,
+      };
+    }),
+  });
+}
+
+async function main() {
+  const opts = parseCliOptions();
+
+  if (opts.help) {
+    console.log(usage());
+    return;
+  }
+
+  applyProviderOverride(opts.provider);
+
+  if (opts["prompt-version"]) {
+    process.env.EXTRACTION_PROMPT_VERSION = opts["prompt-version"];
+  }
+
+  if (opts.model) {
+    process.env.OLLAMA_MODEL = opts.model;
+  }
+
+  resetEnvCache();
+  const env = getEnv();
+
+  const labelDataset = await readEvaluationDataset(opts.labels ?? DEFAULT_LABELS_PATH);
+  const limit = parseLimit(opts.limit);
+  const dataset = isDbMode(opts)
+    ? await loadDbDataset({
+        labelDataset,
+        source: opts.source,
+        since: opts.since,
+        until: opts.until,
+        limit,
+      })
+    : labelDataset;
+
+  const report = await evaluateExtractionDataset({
+    dataset,
+    deps: {
+      extractionService: createIncidentExtractionService(),
+      geocodingService: createGeocodingService(),
+      auditService: createIncidentAuditService(),
+    },
+    run: {
+      source: opts.source ?? null,
+      since: opts.since ?? null,
+      until: opts.until ?? null,
+      promptVersion: env.EXTRACTION_PROMPT_VERSION,
+      model: env.OLLAMA_MODEL,
+    },
+  });
+  const json = JSON.stringify(report, null, opts.pretty ? 2 : 0);
+
+  if (opts.output) {
+    await writeFile(opts.output, `${json}\n`, "utf8");
+  } else {
+    console.log(json);
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDbPool();
+  });

--- a/tests/evaluate-extraction.test.ts
+++ b/tests/evaluate-extraction.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  evaluateExtractionDataset,
+  evaluationDatasetSchema,
+} from "../lib/services/evaluate-extraction";
+import type { PublishDecision } from "../lib/types/domain";
+
+function publishDecision(): PublishDecision {
+  return {
+    route: "direct_publish",
+    publishable: true,
+    audited: false,
+    actions: [],
+    reasons: [],
+    initialConfidence: 0.9,
+    finalConfidence: 0.9,
+    needsReview: false,
+    provider: "test",
+    metadata: {},
+  };
+}
+
+test("computes publish, skip, location, and escalation metrics", async () => {
+  const dataset = evaluationDatasetSchema.parse({
+    name: "test-eval",
+    items: [
+      {
+        id: "publish-theft",
+        transcript: "Theft at 8101 Waynesboro.",
+        label: "8101 Waynesboro",
+        expected: {
+          publish: true,
+          category: "Theft",
+          severity: 2,
+          locationText: "8101 Waynesboro",
+          needsReview: false,
+        },
+      },
+      {
+        id: "skip-clear",
+        transcript: "13 York Clear 22 54.",
+        expected: {
+          publish: false,
+          needsReview: false,
+        },
+      },
+      {
+        id: "false-positive-alarm",
+        transcript: "Alarm at 200 Main Street.",
+        label: "200 Main Street",
+        expected: {
+          publish: false,
+        },
+      },
+    ],
+  });
+
+  const report = await evaluateExtractionDataset({
+    dataset,
+    deps: {
+      extractionService: {
+        extractFromTranscript: async (input) => {
+          const transcript = typeof input === "string" ? input : input.transcript;
+          if (transcript.includes("Clear")) {
+            return {
+              incident: {
+                incidentType: null,
+                category: "13 York Clear 22",
+                locationText: null,
+                address: null,
+                summary: transcript,
+                severity: 1,
+                statusHint: "clear",
+                confidence: 0.5,
+                needsReview: false,
+                matchedCodes: [
+                  {
+                    code: "clear",
+                    meaning: "Clear",
+                    role: "status",
+                    category: null,
+                    severity: null,
+                    statusHint: "clear",
+                    source: "test",
+                    notes: null,
+                  },
+                ],
+              },
+              metadata: {
+                provider: "heuristic",
+                model: null,
+                promptVersion: null,
+                fallbackUsed: false,
+                fallbackReason: null,
+                rawPayload: null,
+                validated: true,
+              },
+            };
+          }
+
+          const isTheft = transcript.includes("Theft");
+          return {
+            incident: {
+              incidentType: isTheft ? "Theft" : "Alarm",
+              category: isTheft ? "Theft" : "Alarm",
+              locationText: isTheft ? "8101 Waynesboro" : "200 Main Street",
+              address: isTheft ? "8101 Waynesboro" : "200 Main Street",
+              summary: transcript,
+              severity: isTheft ? 2 : 1,
+              statusHint: "new",
+              confidence: 0.9,
+              needsReview: false,
+              matchedCodes: [],
+            },
+            metadata: {
+              provider: "heuristic",
+              model: null,
+              promptVersion: null,
+              fallbackUsed: false,
+              fallbackReason: null,
+              rawPayload: null,
+              validated: true,
+            },
+          };
+        },
+      },
+      geocodingService: {
+        geocode: async () => ({
+          provider: "test",
+          resolved: true,
+          confidence: 0.95,
+          query: "test",
+          reason: null,
+          point: { lat: 39.43, lng: -84.21 },
+        }),
+      },
+      auditService: {
+        review: () => publishDecision(),
+      },
+    },
+    run: {
+      source: "openmhz",
+      since: null,
+      until: null,
+      promptVersion: "v-test",
+      model: "model-test",
+      generatedAt: "2026-04-29T00:00:00.000Z",
+    },
+  });
+
+  assert.equal(report.run.datasetName, "test-eval");
+  assert.equal(report.metrics.total, 3);
+  assert.equal(report.metrics.truePositive, 1);
+  assert.equal(report.metrics.falsePositive, 1);
+  assert.equal(report.metrics.trueNegative, 1);
+  assert.equal(report.metrics.falseNegative, 0);
+  assert.equal(report.metrics.publishPrecision, 0.5);
+  assert.equal(report.metrics.falsePositiveRate, 0.5);
+  assert.equal(report.metrics.skipRate, 0.3333);
+  assert.equal(report.metrics.categoryAccuracy, 1);
+  assert.equal(report.metrics.severityAccuracy, 1);
+  assert.equal(report.metrics.locationExtractionAccuracy, 1);
+  assert.equal(report.results[1].route, "skipped_no_incident_signal");
+});


### PR DESCRIPTION
## Summary
- Adds a read-only extraction evaluation harness for issue #27.
- Adds `npm run eval:extraction` with fixture mode and historical `source_calls` mode.
- Adds a small Warren County labeled sample dataset for publish/skip, category, severity, location, review, escalation, and suppression metrics.
- Documents evaluation workflows in the replay runbook.

## How to test
```bash
npm run typecheck
npm test
npm run eval:extraction -- --provider heuristic --pretty
npm run build
```

## Notes
- The evaluator does not enqueue jobs, write enrichment runs, or upsert incidents.
- Historical DB mode can use labels matched by `sourceCallId` or `sourceEventId`; unlabeled historical rows default to expected publish for smoke checks.
- Build passes with the existing non-failing Turbopack NFT tracing warning around the OpenMHz fixture import path.
