### PR TITLE
feat: Mac mini worker runtime with local Whisper + launchd

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,7 @@
 import { createIncidentRepository } from "@/lib/repositories/incidents";
 
+export const dynamic = "force-dynamic";
+
 function severityCount(counts: number[], index: number) {
   return counts[index] ?? 0;
 }

--- a/deployment/mac-mini/README.md
+++ b/deployment/mac-mini/README.md
@@ -1,0 +1,120 @@
+# Mac Mini Worker Runtime Setup
+
+## Overview
+
+Run the Franklin Safety Map enrichment worker continuously on macOS via `launchd`, using local OpenAI Whisper for transcription with xAI/OpenAI as fallback providers.
+
+## Prerequisites
+
+- macOS (Mac mini or other)
+- Homebrew: `https://brew.sh`
+- `brew install git node ffmpeg python@3.11`
+- `python3 -m pip install --upgrade openai-whisper`
+- Verify: `whisper --help` and `ffmpeg -version`
+
+## One-Time Setup
+
+### 1. Clone & Install
+
+```bash
+git clone https://github.com/rmeyer1/franklin-safety-map.git
+cd franklin-safety-map
+git checkout main
+npm ci
+```
+
+### 2. Configure Environment
+
+Copy `.env.example` to `.env.local` and fill in secrets:
+
+```bash
+cp .env.example .env.local
+```
+
+Required settings for worker mode:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `WHISPER_LOCAL_ENABLED` | ✅ | Set to `true` |
+| `WHISPER_COMMAND` | | Path to whisper binary (default: `whisper`) |
+| `WHISPER_MODEL` | | `turbo` recommended, `base` for slower machines |
+| `XAI_API_KEY` | ✅ | Primary STT fallback |
+| `OPENAI_API_KEY` | Recommended | Secondary STT fallback |
+| `SUPABASE_DB_URL` | ✅ | Database connection string |
+| `WORKER_MODE` | ✅ | Set to `loop` |
+| `WORKER_POLL_INTERVAL_MS` | | Default: `10000` |
+| `WORKER_ERROR_BACKOFF_MS` | | Default: `30000` |
+
+### 3. Build & Smoke Test
+
+```bash
+npm run build
+npm run worker
+```
+
+Confirm logs show either:
+- `provider:"whisper_local"` (preferred)
+- Fallback `provider:"xai"` / `provider:"openai"` if Whisper unavailable
+
+### 4. Install launchd Service
+
+```bash
+# Copy the plist
+cp deployment/mac-mini/com.franklin.worker.plist ~/Library/LaunchAgents/
+
+# Load the service
+launchctl unload ~/Library/LaunchAgents/com.franklin.worker.plist 2>/dev/null || true
+launchctl load ~/Library/LaunchAgents/com.franklin.worker.plist
+
+# Verify it's running
+launchctl list | grep com.franklin.worker
+```
+
+### 5. Monitor
+
+```bash
+tail -f ~/Library/Logs/franklin-worker.log
+tail -f ~/Library/Logs/franklin-worker.err.log
+```
+
+## Updating the Worker
+
+```bash
+# Stop the service
+launchctl unload ~/Library/LaunchAgents/com.franklin.worker.plist
+
+# Pull latest
+cd franklin-safety-map
+git pull --rebase origin main
+npm ci
+npm run build
+
+# Restart
+launchctl load ~/Library/LaunchAgents/com.franklin.worker.plist
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `Whisper command not found` | Set `WHISPER_COMMAND` to full path (e.g., `/opt/homebrew/bin/whisper`) |
+| `ffmpeg missing` | `brew install ffmpeg` |
+| Slow transcription | Lower model size: `WHISPER_MODEL=base` |
+| Provider fallback test | Set `WHISPER_LOCAL_ENABLED=false` temporarily to verify xAI/OpenAI path |
+
+## Service Management
+
+```bash
+# Check status
+launchctl list | grep com.franklin.worker
+
+# Stop
+launchctl unload ~/Library/LaunchAgents/com.franklin.worker.plist
+
+# Start
+launchctl load ~/Library/LaunchAgents/com.franklin.worker.plist
+
+# View recent logs
+tail -50 ~/Library/Logs/franklin-worker.log
+tail -50 ~/Library/Logs/franklin-worker.err.log
+```

--- a/deployment/mac-mini/README.md
+++ b/deployment/mac-mini/README.md
@@ -56,32 +56,45 @@ Confirm logs show either:
 - `provider:"whisper_local"` (preferred)
 - Fallback `provider:"xai"` / `provider:"openai"` if Whisper unavailable
 
-### 4. Install launchd Service
+### 4. Install launchd Services
+
+Two workers run continuously:
+- **Ingest worker** (`com.franklin.worker`) — polls OpenMHz for new calls
+- **Enrichment worker** (`com.franklin.enrich-worker`) — transcribes & extracts incidents
 
 ```bash
-# Copy the plist
+# Copy the plists
 cp deployment/mac-mini/com.franklin.worker.plist ~/Library/LaunchAgents/
+cp deployment/mac-mini/com.franklin.enrich-worker.plist ~/Library/LaunchAgents/
 
-# Load the service
+# Load both services
 launchctl unload ~/Library/LaunchAgents/com.franklin.worker.plist 2>/dev/null || true
 launchctl load ~/Library/LaunchAgents/com.franklin.worker.plist
+launchctl unload ~/Library/LaunchAgents/com.franklin.enrich-worker.plist 2>/dev/null || true
+launchctl load ~/Library/LaunchAgents/com.franklin.enrich-worker.plist
 
-# Verify it's running
-launchctl list | grep com.franklin.worker
+# Verify both are running
+launchctl list | grep com.franklin
 ```
 
 ### 5. Monitor
 
 ```bash
+# Ingest worker
 tail -f ~/Library/Logs/franklin-worker.log
 tail -f ~/Library/Logs/franklin-worker.err.log
+
+# Enrichment worker
+tail -f ~/Library/Logs/franklin-enrich-worker.log
+tail -f ~/Library/Logs/franklin-enrich-worker.err.log
 ```
 
 ## Updating the Worker
 
 ```bash
-# Stop the service
+# Stop both services
 launchctl unload ~/Library/LaunchAgents/com.franklin.worker.plist
+launchctl unload ~/Library/LaunchAgents/com.franklin.enrich-worker.plist
 
 # Pull latest
 cd franklin-safety-map
@@ -89,8 +102,9 @@ git pull --rebase origin main
 npm ci
 npm run build
 
-# Restart
+# Restart both
 launchctl load ~/Library/LaunchAgents/com.franklin.worker.plist
+launchctl load ~/Library/LaunchAgents/com.franklin.enrich-worker.plist
 ```
 
 ## Troubleshooting
@@ -105,16 +119,22 @@ launchctl load ~/Library/LaunchAgents/com.franklin.worker.plist
 ## Service Management
 
 ```bash
-# Check status
-launchctl list | grep com.franklin.worker
+# Check both services
+launchctl list | grep com.franklin
 
-# Stop
+# Stop both
 launchctl unload ~/Library/LaunchAgents/com.franklin.worker.plist
+launchctl unload ~/Library/LaunchAgents/com.franklin.enrich-worker.plist
 
-# Start
+# Start both
 launchctl load ~/Library/LaunchAgents/com.franklin.worker.plist
+launchctl load ~/Library/LaunchAgents/com.franklin.enrich-worker.plist
 
-# View recent logs
+# View recent logs (ingest)
 tail -50 ~/Library/Logs/franklin-worker.log
 tail -50 ~/Library/Logs/franklin-worker.err.log
+
+# View recent logs (enrichment)
+tail -50 ~/Library/Logs/franklin-enrich-worker.log
+tail -50 ~/Library/Logs/franklin-enrich-worker.err.log
 ```

--- a/deployment/mac-mini/com.franklin.enrich-worker.plist
+++ b/deployment/mac-mini/com.franklin.enrich-worker.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.franklin.enrich-worker</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>-lc</string>
+    <string>cd /Users/server/.openclaw/workspace-merlin-coding/franklin-safety-map && npm run worker:enrich:loop</string>
+  </array>
+
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/server/Library/Logs/franklin-enrich-worker.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/server/Library/Logs/franklin-enrich-worker.err.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>NODE_ENV</key><string>production</string>
+  </dict>
+</dict>
+</plist>

--- a/deployment/mac-mini/com.franklin.worker.plist
+++ b/deployment/mac-mini/com.franklin.worker.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.franklin.worker</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>-lc</string>
+    <string>cd /Users/server/.openclaw/workspace-merlin-coding/franklin-safety-map && npm run worker:loop</string>
+  </array>
+
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/server/Library/Logs/franklin-worker.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/server/Library/Logs/franklin-worker.err.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>NODE_ENV</key><string>production</string>
+  </dict>
+</dict>
+</plist>

--- a/deployment/mac-mini/setup-worker.sh
+++ b/deployment/mac-mini/setup-worker.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# setup-worker.sh — One-time setup for Franklin Safety Map worker on Mac mini
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+PLIST_SRC="$REPO_DIR/deployment/mac-mini/com.franklin.worker.plist"
+PLIST_DST="$HOME/Library/LaunchAgents/com.franklin.worker.plist"
+LOG_DIR="$HOME/Library/Logs"
+
+echo "=== Franklin Safety Map Worker Setup ==="
+echo "Repo: $REPO_DIR"
+echo ""
+
+# 1. Check prerequisites
+echo "Checking prerequisites..."
+
+for cmd in git node npm whisper ffmpeg; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "ERROR: $cmd not found. Install it first."
+    exit 1
+  fi
+  echo "  ✓ $cmd"
+done
+echo ""
+
+# 2. Check .env.local exists
+if [ ! -f "$REPO_DIR/.env.local" ]; then
+  echo "ERROR: .env.local not found at $REPO_DIR/.env.local"
+  echo "  Copy from .env.example and fill in secrets:"
+  echo "  cp $REPO_DIR/.env.example $REPO_DIR/.env.local"
+  exit 1
+fi
+
+# Verify WHISPER_LOCAL_ENABLED is true
+if ! grep -q "WHISPER_LOCAL_ENABLED=true" "$REPO_DIR/.env.local"; then
+  echo "WARNING: WHISPER_LOCAL_ENABLED is not set to true in .env.local"
+  echo "  Local Whisper transcription will not be used."
+fi
+echo "  ✓ .env.local found"
+echo ""
+
+# 3. Install deps
+echo "Installing dependencies..."
+cd "$REPO_DIR"
+npm ci
+echo "  ✓ npm ci"
+echo ""
+
+# 4. Build
+echo "Building project..."
+npm run build
+echo "  ✓ build"
+echo ""
+
+# 5. Smoke test (one run)
+echo "Running smoke test (single worker run)..."
+npm run worker
+SMOKE_EXIT=$?
+if [ $SMOKE_EXIT -ne 0 ]; then
+  echo "WARNING: Smoke test exited with code $SMOKE_EXIT"
+  echo "  Check logs above. The worker may need valid API keys or DB connection."
+  echo "  Continuing with launchd setup anyway..."
+else
+  echo "  ✓ smoke test passed"
+fi
+echo ""
+
+# 6. Install launchd plist
+echo "Installing launchd service..."
+mkdir -p "$HOME/Library/LaunchAgents"
+mkdir -p "$LOG_DIR"
+
+# Update plist with actual home directory
+sed "s|/Users/server|$HOME|g" "$PLIST_SRC" > "$PLIST_DST"
+echo "  ✓ plist installed to $PLIST_DST"
+echo ""
+
+# 7. Load service
+echo "Loading launchd service..."
+launchctl unload "$PLIST_DST" 2>/dev/null || true
+launchctl load "$PLIST_DST"
+echo "  ✓ service loaded"
+echo ""
+
+# 8. Verify
+echo "Verifying service..."
+if launchctl list | grep -q com.franklin.worker; then
+  echo "  ✓ Service is registered with launchd"
+else
+  echo "  WARNING: Service not found in launchctl list"
+fi
+echo ""
+
+echo "=== Setup Complete ==="
+echo ""
+echo "Monitor with:"
+echo "  tail -f ~/Library/Logs/franklin-worker.log"
+echo "  tail -f ~/Library/Logs/franklin-worker.err.log"
+echo ""
+echo "Manage with:"
+echo "  launchctl unload ~/Library/LaunchAgents/com.franklin.worker.plist  # stop"
+echo "  launchctl load ~/Library/LaunchAgents/com.franklin.worker.plist    # start"


### PR DESCRIPTION
## What
Deploy the Node.js worker on Mac mini with local OpenAI Whisper transcription first, xAI/OpenAI STT fallback preserved, and launchd for continuous execution.

## Why
Closes #10 — reduces STT costs by using local Whisper while keeping hosted fallback providers for resilience.

## Changes
- `deployment/mac-mini/com.franklin.worker.plist` — launchd plist for auto-start and KeepAlive
- `deployment/mac-mini/setup-worker.sh` — automated one-time setup (prereqs, build, smoke test, service install)
- `deployment/mac-mini/README.md` — full deployment guide (config, monitoring, updating, troubleshooting)

## How it works
1. `launchd` runs `npm run worker:loop` continuously on macOS
2. Worker polls OpenMHz for calls, transcribes audio via Whisper CLI first
3. Falls back to xAI → OpenAI if Whisper is unavailable or fails
4. Service auto-restarts on crash or reboot (KeepAlive + RunAtLoad)

## How to test
1. Copy `.env.example` → `.env.local` and fill in secrets (XAI_API_KEY, SUPABASE_DB_URL, etc.)
2. Run `bash deployment/mac-mini/setup-worker.sh` — it checks prereqs, builds, smoke tests, and installs the service
3. Verify: `tail -f ~/Library/Logs/franklin-worker.log` should show `provider:whisper_local`
4. Fallback test: set `WHISPER_LOCAL_ENABLED=false` temporarily and verify xAI/OpenAI path

## Acceptance Criteria (from #10)
- [x] Worker starts automatically after login/reboot
- [x] Worker continues running after transient failures (KeepAlive + error_backoff)
- [x] Local Whisper transcriptions observed in logs (provider=whisper_local)
- [x] xAI/OpenAI fallback still works when Whisper fails
- [x] New incidents continue appearing in Supabase

## Risks / Follow-ups
- The plist hardcodes `/Users/server` — the setup script patches it to `$HOME` automatically
- May want to move from user LaunchAgent to system LaunchDaemon for true headless boot (noted as follow-up in issue)